### PR TITLE
Enable JIT mode

### DIFF
--- a/lib/install/stylesheets/tailwind.config.js
+++ b/lib/install/stylesheets/tailwind.config.js
@@ -1,9 +1,11 @@
 module.exports = {
   // Purge unused TailwindCSS styles
+  mode: 'jit',
   purge: {
     enabled: ["production"].includes(process.env.NODE_ENV),
     content: [
       './**/*.html.erb',
+      './**/*.scss',
       './app/helpers/**/*.rb',
       './app/javascript/**/*.js',
     ],

--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -2,7 +2,7 @@ WEBPACK_STYLESHEETS_PATH = "#{Webpacker.config.source_path}/stylesheets"
 APPLICATION_LAYOUT_PATH  = Rails.root.join("app/views/layouts/application.html.erb")
 
 say "Installing Tailwind CSS"
-run "yarn add tailwindcss@npm:@tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9"
+run "yarn add tailwindcss@latest postcss@latest autoprefixer@latest webpack-dev-server@3.11.2"
 insert_into_file "#{Webpacker.config.source_entry_path}/application.js", "\nimport \"stylesheets/application\"\n"
 
 say "Configuring Tailwind CSS"


### PR DESCRIPTION
- Now using latest tailwind and dependent packages
- Enabled JIT mode

In order for the JIT mode to work the dev-server needs to be set to a version previous to 4.0.0